### PR TITLE
Fixed typos and made functions POSIX compatible

### DIFF
--- a/scripts/act-bootstrap.sh
+++ b/scripts/act-bootstrap.sh
@@ -2,17 +2,17 @@
 
 set -e
 
-function log {
+log() {
     echo "`date` [BOOTSTRAP] $1"
 }
 
-function usage {
+usage() {
     echo ""
     echo "syntax: bootstrap.sh <user id> <act baseurl>"
     echo "example: bootstrap.sh 1 http://localhost:8888"
 }
 
-BOOTSTRAP_HOME="`dirname $0`/.."
+BOOTSTRAP_HOME=`dirname $0`/..
 USERID=$1
 ACT_BASEURL=$2
 LOGLEVEL=info
@@ -24,8 +24,7 @@ OBJECT_TYPES=${BOOTSTRAP_HOME}/types/object-types.json
 
 if [ ! -d "$LOGDIR" ]; then
     log "Created log directory $LOGDIR"
-    echo $LOGDIR
-    mkdir ${LOGDIDR}
+    mkdir ${LOGDIR}
 fi
 
 if [ "$USERID" == "" ]; then


### PR DESCRIPTION
Adresses issues mentioned in #14.

Not all shells allow for function definitions by use of the "function" keyword, so this might be why the function is not found. Also fixed the typo and unnecessary echo of "logdir" creation (its already being logged). 